### PR TITLE
Add scheduled endpoint refresh with notifications

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -119,6 +119,19 @@ functions:
           - dynamodb:*
         Resource: !GetAtt CustomerEndpointsTable.Arn
 
+  refreshAllEndpoints:
+    handler: src/functions/endpoints/refresh-all-endpoints.handler
+    events:
+      - schedule:
+          name: ${self:custom.base}-refresh-endpoints
+          description: Refresh endpoint status metadata
+          rate: cron(0/5 * * * ? *)
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:*
+        Resource: !GetAtt CustomerEndpointsTable.Arn
+
 resources:
   - ${file(resources/cognito-user-pool.yml)}
   - ${file(resources/dynamodb-tables.yml)}

--- a/backend/src/functions/endpoints/refresh-all-endpoints.ts
+++ b/backend/src/functions/endpoints/refresh-all-endpoints.ts
@@ -1,0 +1,25 @@
+import { endpointService } from '@service/endpoint-service';
+
+export const handler = async () => {
+  try {
+    const updatedEndpoints = await endpointService.refreshAllEndpoints();
+    const unhealthyCount = updatedEndpoints.filter(
+      (endpoint) => endpoint.status === 'unhealthy'
+    ).length;
+
+    console.log('Completed scheduled endpoint refresh', {
+      refreshed: updatedEndpoints.length,
+      unhealthyCount,
+    });
+
+    return {
+      refreshed: updatedEndpoints.length,
+      unhealthyCount,
+    };
+  } catch (error) {
+    console.error('Failed to refresh endpoints on schedule', {
+      error,
+    });
+    throw error;
+  }
+};

--- a/backend/src/service/notification-service.ts
+++ b/backend/src/service/notification-service.ts
@@ -1,0 +1,34 @@
+import { EndpointModel } from '@model/endpoint-model';
+import { CheckEndpointResult } from '@lib/check-endpoint';
+
+class NotificationService {
+  async notifyEndpointIssue(
+    endpoint: EndpointModel,
+    checkResult: CheckEndpointResult
+  ): Promise<void> {
+    const issueDetail =
+      checkResult.errorMessage ||
+      (checkResult.statusCode
+        ? `Received status code ${checkResult.statusCode}`
+        : 'Unknown issue');
+
+    console.log(
+      '[MockNotification] Endpoint unhealthy',
+      JSON.stringify(
+        {
+          ownerId: endpoint.ownerId,
+          tenantId: endpoint.tenantId,
+          endpointId: endpoint.endpointId,
+          name: endpoint.name,
+          url: endpoint.url,
+          issue: issueDetail,
+          checkedAt: endpoint.lastCheckedAt,
+        },
+        null,
+        2
+      )
+    );
+  }
+}
+
+export const notificationService = new NotificationService();

--- a/backend/src/store/endpoint-store.ts
+++ b/backend/src/store/endpoint-store.ts
@@ -14,6 +14,10 @@ export class EndpointStore extends DynamoStoreRepository<EndpointModel> {
     return this.query().wherePartitionKey(ownerId).execFetchAll();
   };
 
+  listAllEndpoints = async (): Promise<EndpointModel[]> => {
+    return this.scan().execFetchAll();
+  };
+
   updateEndpoint = async (
     ownerId: string,
     endpointId: string,


### PR DESCRIPTION
## Summary
- add a scheduled lambda that refreshes every endpoint and records a summary log
- reuse endpoint refresh logic for owner-triggered refreshes and add support for scanning all tenants
- send mock notifications whenever an endpoint is detected as unhealthy during scheduled refreshes

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfa1b144e0832db190b7e44b4efb86