### PR TITLE
Simplify manual deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,24 @@ name: Deploy Dev
 
 on:
   workflow_dispatch:
+    inputs:
+      aws_access_key_id:
+        description: 'AWS access key with permissions to deploy the stack'
+        required: true
+      aws_secret_access_key:
+        description: 'AWS secret access key matching the IAM user above'
+        required: true
+      webapp_bucket:
+        description: 'Unique S3 bucket name for hosting the React frontend'
+        required: true
+      aws_region:
+        description: 'AWS region to target (defaults to us-east-1)'
+        required: false
+        default: us-east-1
+      stage:
+        description: 'Serverless stage/environment name'
+        required: false
+        default: dev
   push:
     branches:
       - master
@@ -12,18 +30,18 @@ concurrency:
 
 env:
   AWS_PROFILE: default
-  ENV: dev
-  ENV_NAME: dev
+  AWS_DEFAULT_REGION: ${{ github.event.inputs.aws_region || 'us-east-1' }}
+  ENV: ${{ github.event.inputs.stage || 'dev' }}
+  ENV_NAME: ${{ github.event.inputs.stage || 'dev' }}
 jobs:
   deploy-backend:
     runs-on: ubuntu-20.04
     environment:
-      name: dev
+      name: ${{ env.ENV_NAME }}
     env:
-      AWS_ACCESS_KEY_ID: ${{vars.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_access_key_id || vars.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_secret_access_key || secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
-      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,7 +68,6 @@ jobs:
         run: |
           mkdir ~/.aws
           echo -e "[${AWS_PROFILE}]\naws_access_key_id=${AWS_ACCESS_KEY_ID}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY}\n" > ~/.aws/credentials
-          cat ~/.aws/credentials
 
       - name: Deploy backend environment
         run: |
@@ -70,13 +87,12 @@ jobs:
     needs: deploy-backend
     runs-on: ubuntu-20.04
     environment:
-      name: dev
+      name: ${{ env.ENV_NAME }}
     env:
-      AWS_ACCESS_KEY_ID: ${{vars.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      WEBAPP_BUCKET: ${{vars.WEBAPP_BUCKET}}
+      AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_access_key_id || vars.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_secret_access_key || secrets.AWS_SECRET_ACCESS_KEY }}
+      WEBAPP_BUCKET: ${{ github.event.inputs.webapp_bucket || vars.WEBAPP_BUCKET }}
       AWS_EC2_METADATA_DISABLED: true
-      AWS_DEFAULT_REGION: us-east-1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -115,7 +131,6 @@ jobs:
         run: |
           mkdir ~/.aws
           echo -e "[${AWS_PROFILE}]\naws_access_key_id=${AWS_ACCESS_KEY_ID}\naws_secret_access_key=${AWS_SECRET_ACCESS_KEY}\n" > ~/.aws/credentials
-          cat ~/.aws/credentials
 
       - name: Check if S3 Bucket Exists
         id: check-bucket

--- a/README.md
+++ b/README.md
@@ -51,3 +51,81 @@ npm test
 ```
 
 The frontend relies on manual verification for this assignment; the UI is intentionally kept minimal to reflect a 2–3 hour implementation window.
+
+## Deployment & operations
+
+### Architecture choices
+
+As discussed in the zoom I made it "My Own" So I can showcase my way of thinking and how I would approach this kind of task.
+
+- serverless framework as my IaC to be able to update and redeploy changes easily.
+- Lambda for scalability and simplicity (Not having to manage Containers lifecycle)
+- API Gateway
+  - Fully managed makes it easy for developers to create, publish, maintain, monitor
+  - Secure APIs at any scale.
+  - Input schema validation capabilities.
+- Cognito and Amplify for authentication and authorisation
+  - Offers user interface
+  - Scalability and Security
+  - Simple Integration with AWS Services
+- S3 as the static website hosting
+  - Cost-Effective Hosting
+  - High Scalability and Availability
+  - Easy Deployment and Maintenance
+  - Simple to Update
+- For CI/CD i am using GitHub actions
+  - to streamline the deployment process so the BE and FE are updated automatically on every 'master' push.
+
+### Gaps and Nice to Haves
+
+- Static website hosting in s3
+  - currently it uses http protocol and not https. I would have set certificate to make it https
+- React:
+  - The code could be much cleaner and be split into smaller components and files.
+  - Could have used a modern state management and lifecycle tool like redux or react-query.
+  - Nicer layout with proper CSS
+  - Fetching by clicking the next page and not the NEXT button.
+  - Saved repos are not automatically updated with the current number of stars (could be nice to implement)
+- CI/CD
+  - Could be nice to skip backend or frontend in no code was changed in either respectively
+  - Create env per PR for testing before merging to master
+
+### Fork the Repository
+
+To run this project in your own AWS account, you should first fork this repository:
+
+1. Navigate to the original repository on GitHub.
+2. Click the "Fork" button in the top-right corner of the page.
+
+### Prerequisites
+
+- AWS Account
+- GitHub Account
+
+### Setting up a Development Environment in GitHub
+
+The simplified workflow can be dispatched without configuring repository environments or secrets. You only need temporary AWS credentials with permission to deploy the Serverless stack and the name of an S3 bucket for the frontend. (If you prefer automated deployments on every push to `master`, you can still store these values as repository secrets or variables and the workflow will fall back to them.)
+
+### Setup Environment Variables in GitHub
+
+There are no persistent variables to configure. Instead, collect the values below so you can paste them into the workflow form when you trigger a deployment:
+
+- **AWS_ACCESS_KEY_ID** – AWS IAM user access key ID with the necessary permissions.
+- **AWS_SECRET_ACCESS_KEY** – Secret key that matches the access key above.
+- **WEBAPP_BUCKET** – Unique S3 bucket name that will host the React frontend (for example `my-uptime-demo-bucket`).
+- **AWS_REGION** *(optional)* – Region for the deployment (defaults to `us-east-1`).
+- **STAGE** *(optional)* – Serverless stage name (defaults to `dev`).
+
+### Creating a Secured Variable in AWS
+
+No additional Parameter Store or Secrets Manager values are required. The workflow writes the credentials you provide into the runner's temporary AWS profile for the duration of the job.
+
+### Deploying the Application
+
+The application is deployed using GitHub Actions. The workflow still runs on pushes to the `master` branch when repository credentials are available, but reviewers can deploy manually without any repository configuration:
+
+1. Go to the "Actions" tab in your GitHub repository and select the **Deploy Dev** workflow.
+2. Click **Run workflow**, supply the AWS access key ID, secret access key, and S3 bucket name (plus optional region or stage) in the input fields, and confirm.
+3. Click **Run workflow** again to start the job. The workflow deploys the backend with Serverless, generates the frontend `.env`, builds the React app, and uploads the artefacts to the chosen bucket.
+
+The endpoint to access the app will be available at the S3 static website URL for the bucket you provided (for example `http://{WEBAPP_BUCKET}.s3-website-us-east-1.amazonaws.com` when using the default region).


### PR DESCRIPTION
## Summary
- accept AWS credential, region, stage, and bucket inputs when manually dispatching the Deploy Dev workflow
- use the supplied inputs (or existing repo configuration) without echoing credentials, so reviewers can deploy without creating secrets
- update the README deployment section to describe the streamlined manual workflow and required values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfa4f352c0832d993b1eb7464397d3