### PR TITLE
Fix deploy workflow environment references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
   deploy-backend:
     runs-on: ubuntu-20.04
     environment:
-      name: ${{ env.ENV_NAME }}
+      name: ${{ github.event.inputs.stage || 'dev' }}
     env:
       AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_access_key_id || vars.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_secret_access_key || secrets.AWS_SECRET_ACCESS_KEY }}
@@ -84,7 +84,7 @@ jobs:
     needs: deploy-backend
     runs-on: ubuntu-20.04
     environment:
-      name: ${{ env.ENV_NAME }}
+      name: ${{ github.event.inputs.stage || 'dev' }}
     env:
       AWS_ACCESS_KEY_ID: ${{ github.event.inputs.aws_access_key_id || vars.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ github.event.inputs.aws_secret_access_key || secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
- resolve the deploy workflow failure by referencing the workflow_dispatch stage input directly when naming environments
- add a trailing newline to the workflow file to keep formatting consistent

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfab9c0d7c832dbf9f3667ef24fe08