### PR TITLE
Add logging for endpoint lambdas and handle refresh updates

### DIFF
--- a/backend/src/common/log-event.ts
+++ b/backend/src/common/log-event.ts
@@ -1,0 +1,127 @@
+import { APIGatewayEvent } from 'aws-lambda';
+
+const MAX_BODY_LOG_LENGTH = 2048;
+
+type HeaderValue = string | undefined;
+
+const isApiGatewayEvent = (event: unknown): event is APIGatewayEvent => {
+  if (!event || typeof event !== 'object') {
+    return false;
+  }
+
+  const candidate = event as Record<string, unknown>;
+
+  return 'httpMethod' in candidate && 'requestContext' in candidate;
+};
+
+const sanitizeHeaders = (
+  headers: APIGatewayEvent['headers'] | null
+): Record<string, HeaderValue> | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+
+  return Object.entries(headers).reduce<Record<string, HeaderValue>>(
+    (acc, [key, value]) => {
+      if (typeof key !== 'string') {
+        return acc;
+      }
+
+      if (key.toLowerCase() === 'authorization') {
+        acc[key] = value ? '[REDACTED]' : value;
+        return acc;
+      }
+
+      acc[key] = value;
+      return acc;
+    },
+    {}
+  );
+};
+
+const summarizeBody = (
+  body: string | null,
+  isBase64Encoded: boolean | undefined
+):
+  | undefined
+  | {
+      length: number;
+      isBase64Encoded: boolean;
+      truncated: boolean;
+      preview?: string;
+    } => {
+  if (!body) {
+    return undefined;
+  }
+
+  if (isBase64Encoded) {
+    return {
+      length: body.length,
+      isBase64Encoded: true,
+      truncated: false,
+    };
+  }
+
+  const truncated = body.length > MAX_BODY_LOG_LENGTH;
+
+  return {
+    length: body.length,
+    isBase64Encoded: false,
+    truncated,
+    preview: truncated ? `${body.slice(0, MAX_BODY_LOG_LENGTH)}...` : body,
+  };
+};
+
+const formatApiGatewayEvent = (event: APIGatewayEvent) => {
+  const { requestContext } = event;
+
+  return {
+    type: 'APIGatewayEvent',
+    httpMethod: event.httpMethod,
+    resource: event.resource,
+    path: event.path,
+    routeKey: requestContext?.routeKey,
+    stage: requestContext?.stage,
+    requestId: requestContext?.requestId,
+    identity: requestContext?.identity
+      ? {
+          sourceIp: requestContext.identity.sourceIp,
+          userAgent: requestContext.identity.userAgent,
+        }
+      : undefined,
+    authorizer: requestContext?.authorizer
+      ? {
+          hasAuthorizer: true,
+          claims: requestContext.authorizer.claims
+            ? {
+                sub: requestContext.authorizer.claims.sub,
+              }
+            : undefined,
+          scopes: requestContext.authorizer.scopes,
+        }
+      : undefined,
+    queryStringParameters: event.queryStringParameters,
+    pathParameters: event.pathParameters,
+    headers: sanitizeHeaders(event.headers),
+    body: summarizeBody(event.body, event.isBase64Encoded),
+  };
+};
+
+const formatLambdaEvent = (event: unknown) => {
+  if (isApiGatewayEvent(event)) {
+    return formatApiGatewayEvent(event);
+  }
+
+  return event ?? null;
+};
+
+export const logLambdaEvent = (message: string, event: unknown) => {
+  try {
+    console.log(message, {
+      event: formatLambdaEvent(event),
+    });
+  } catch (error) {
+    console.log(`Failed to log event for ${message}`, { error });
+  }
+};
+

--- a/backend/src/functions/endpoints/create-endpoint.ts
+++ b/backend/src/functions/endpoints/create-endpoint.ts
@@ -1,8 +1,10 @@
 import { endpointService } from '@service/endpoint-service';
 import { httpError, httpResponse } from '@common/http-response';
+import { logLambdaEvent } from '@common/log-event';
 import { APIGatewayEvent } from 'aws-lambda';
 
 export const handler = async (event: APIGatewayEvent) => {
+  logLambdaEvent('Received create-endpoint request', event);
   try {
     const claims = event.requestContext.authorizer?.claims;
     const ownerId = claims?.sub;

--- a/backend/src/functions/endpoints/list-endpoints.ts
+++ b/backend/src/functions/endpoints/list-endpoints.ts
@@ -1,8 +1,10 @@
 import { endpointService } from '@service/endpoint-service';
 import { httpError, httpResponse } from '@common/http-response';
+import { logLambdaEvent } from '@common/log-event';
 import { APIGatewayEvent } from 'aws-lambda';
 
 export const handler = async (event: APIGatewayEvent) => {
+  logLambdaEvent('Received list-endpoints request', event);
   try {
     const claims = event.requestContext.authorizer?.claims;
     const ownerId = claims?.sub;

--- a/backend/src/functions/endpoints/refresh-all-endpoints.ts
+++ b/backend/src/functions/endpoints/refresh-all-endpoints.ts
@@ -1,6 +1,9 @@
+import { logLambdaEvent } from '@common/log-event';
 import { endpointService } from '@service/endpoint-service';
+import { ScheduledEvent } from 'aws-lambda';
 
-export const handler = async () => {
+export const handler = async (event?: ScheduledEvent) => {
+  logLambdaEvent('Received refresh-all-endpoints event', event);
   try {
     const updatedEndpoints = await endpointService.refreshAllEndpoints();
     const unhealthyCount = updatedEndpoints.filter(

--- a/backend/src/service/endpoint-service.ts
+++ b/backend/src/service/endpoint-service.ts
@@ -58,17 +58,23 @@ class EndpointService {
     const statusChanged = endpoint.status !== newStatus;
     const nowIso = new Date().toISOString();
 
+    const updatePayload: Partial<EndpointModel> = {
+      status: newStatus,
+      statusCode: checkResult.statusCode,
+      responseTimeMs: checkResult.responseTimeMs,
+      errorMessage: checkResult.errorMessage,
+      lastCheckedAt: nowIso,
+      statusSince: statusChanged ? nowIso : endpoint.statusSince,
+    };
+
+    const sanitizedUpdatePayload = Object.fromEntries(
+      Object.entries(updatePayload).filter(([, value]) => value !== undefined)
+    ) as Partial<EndpointModel>;
+
     const updatedEndpoint = await this.endpointStore.updateEndpoint(
       endpoint.ownerId,
       endpoint.endpointId,
-      {
-        status: newStatus,
-        statusCode: checkResult.statusCode,
-        responseTimeMs: checkResult.responseTimeMs,
-        errorMessage: checkResult.errorMessage,
-        lastCheckedAt: nowIso,
-        statusSince: statusChanged ? nowIso : endpoint.statusSince,
-      }
+      sanitizedUpdatePayload
     );
 
     await this.notifyIfUnhealthy(updatedEndpoint, checkResult);


### PR DESCRIPTION
## Summary
- add a shared logger to capture sanitized Lambda event details and use it across all endpoint handlers
- log scheduled refresh invocations and allow handlers to log their triggering events
- prevent refresh updates from sending undefined values to Dynamo by stripping them before persisting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfb6d66130832db08c99eb8a1106ba