### PR TITLE
Enable endpoint updates and tenant deletion

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -119,6 +119,35 @@ functions:
           - dynamodb:*
         Resource: !GetAtt CustomerEndpointsTable.Arn
 
+  updateEndpoint:
+    handler: src/functions/endpoints/update-endpoint.handler
+    events:
+      - http:
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+          path: monitoring/endpoints/{endpointId}
+          method: patch
+          cors: true
+          request:
+            schema:
+              application/json:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  url:
+                    type: string
+                  timeoutMs:
+                    type: integer
+                    minimum: 1
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:*
+        Resource: !GetAtt CustomerEndpointsTable.Arn
+
   refreshAllEndpoints:
     handler: src/functions/endpoints/refresh-all-endpoints.handler
     events:
@@ -126,6 +155,23 @@ functions:
           name: ${self:custom.base}-refresh-endpoints
           description: Refresh endpoint status metadata
           rate: cron(0/5 * * * ? *)
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:*
+        Resource: !GetAtt CustomerEndpointsTable.Arn
+
+  deleteTenant:
+    handler: src/functions/tenants/delete-tenant.handler
+    events:
+      - http:
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+          path: monitoring/tenants/{tenantId}
+          method: delete
+          cors: true
     iamRoleStatements:
       - Effect: Allow
         Action:

--- a/backend/src/functions/endpoints/update-endpoint.ts
+++ b/backend/src/functions/endpoints/update-endpoint.ts
@@ -1,0 +1,54 @@
+import { endpointService } from '@service/endpoint-service';
+import { httpError, httpResponse } from '@common/http-response';
+import { logLambdaEvent } from '@common/log-event';
+import { APIGatewayEvent } from 'aws-lambda';
+
+export const handler = async (event: APIGatewayEvent) => {
+  logLambdaEvent('Received update-endpoint request', event);
+  try {
+    const claims = event.requestContext.authorizer?.claims;
+    const ownerId = claims?.sub;
+
+    if (!ownerId) {
+      return httpError(new Error('Unauthorized'), 401);
+    }
+
+    const endpointId = event.pathParameters?.endpointId;
+
+    if (!endpointId) {
+      return httpError(new Error('endpointId path parameter is required'), 400);
+    }
+
+    if (!event.body) {
+      return httpError(new Error('Request body is required'), 400);
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(event.body);
+    } catch (error) {
+      return httpError(new Error('Invalid JSON body'), 400);
+    }
+
+    const { name, url, timeoutMs } = payload;
+
+    if (name === undefined && url === undefined && timeoutMs === undefined) {
+      return httpError(
+        new Error('At least one of name, url or timeoutMs must be provided'),
+        400
+      );
+    }
+
+    const endpoint = await endpointService.updateEndpoint(ownerId, endpointId, {
+      name: typeof name === 'string' ? name : undefined,
+      url: typeof url === 'string' ? url : undefined,
+      timeoutMs: typeof timeoutMs === 'number' ? timeoutMs : undefined,
+    });
+
+    return httpResponse(endpoint, 200);
+  } catch (err) {
+    console.error('Error updating endpoint', { error: err });
+    const error = err instanceof Error ? err : new Error('Unexpected error');
+    return httpError(error, (error as any).statusCode || 500);
+  }
+};

--- a/backend/src/functions/tenants/delete-tenant.ts
+++ b/backend/src/functions/tenants/delete-tenant.ts
@@ -1,0 +1,30 @@
+import { endpointService } from '@service/endpoint-service';
+import { httpError, httpResponse } from '@common/http-response';
+import { logLambdaEvent } from '@common/log-event';
+import { APIGatewayEvent } from 'aws-lambda';
+
+export const handler = async (event: APIGatewayEvent) => {
+  logLambdaEvent('Received delete-tenant request', event);
+  try {
+    const claims = event.requestContext.authorizer?.claims;
+    const ownerId = claims?.sub;
+
+    if (!ownerId) {
+      return httpError(new Error('Unauthorized'), 401);
+    }
+
+    const tenantId = event.pathParameters?.tenantId;
+
+    if (!tenantId) {
+      return httpError(new Error('tenantId path parameter is required'), 400);
+    }
+
+    const deletedCount = await endpointService.deleteTenant(ownerId, tenantId);
+
+    return httpResponse({ tenantId, deletedCount }, 200);
+  } catch (err) {
+    console.error('Error deleting tenant', { error: err });
+    const error = err instanceof Error ? err : new Error('Unexpected error');
+    return httpError(error, (error as any).statusCode || 500);
+  }
+};

--- a/backend/src/store/endpoint-store.ts
+++ b/backend/src/store/endpoint-store.ts
@@ -10,6 +10,13 @@ export class EndpointStore extends DynamoStoreRepository<EndpointModel> {
     return this.putAndGet(endpoint);
   };
 
+  getEndpoint = async (
+    ownerId: string,
+    endpointId: string
+  ): Promise<EndpointModel | null> => {
+    return this.get(ownerId, endpointId).exec();
+  };
+
   listEndpoints = async (ownerId: string): Promise<EndpointModel[]> => {
     return this.query().wherePartitionKey(ownerId).execFetchAll();
   };
@@ -24,5 +31,17 @@ export class EndpointStore extends DynamoStoreRepository<EndpointModel> {
     update: Partial<EndpointModel>
   ): Promise<EndpointModel> => {
     return this.updateByPartitionKeyAndSortKey(ownerId, endpointId, update);
+  };
+
+  deleteEndpoint = async (ownerId: string, endpointId: string): Promise<void> => {
+    await this.delete(ownerId, endpointId).exec();
+  };
+
+  deleteEndpoints = async (endpoints: EndpointModel[]): Promise<void> => {
+    if (endpoints.length === 0) {
+      return;
+    }
+
+    await this.batchDelete(endpoints);
   };
 }

--- a/backend/src/types/Endpoint.ts
+++ b/backend/src/types/Endpoint.ts
@@ -23,3 +23,9 @@ export type EndpointInput = {
   url: string;
   timeoutMs?: number;
 };
+
+export type EndpointUpdateInput = {
+  name?: string;
+  url?: string;
+  timeoutMs?: number;
+};

--- a/frontend/src/types/Endpoint.ts
+++ b/frontend/src/types/Endpoint.ts
@@ -23,3 +23,9 @@ export type EndpointPayload = {
   url: string;
   timeoutMs?: number;
 };
+
+export type EndpointUpdatePayload = {
+  name?: string;
+  url?: string;
+  timeoutMs?: number;
+};


### PR DESCRIPTION
## Summary
- add backend support to update existing endpoints and delete tenant groups
- expose endpoint editing and tenant removal controls in the console UI

## Testing
- npm test -- --runInBand
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cfc66c64dc832db9641e59ada7d92c