### PR TITLE
Rename endpoint form key label to name

### DIFF
--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -334,9 +334,9 @@ const AppContent = ({
                     <Input placeholder="e.g. billing" />
                   </Form.Item>
                   <Form.Item
-                    label="Key"
+                    label="Name"
                     name="name"
-                    rules={[{ required: true, message: 'Key is required' }]}
+                    rules={[{ required: true, message: 'Name is required' }]}
                   >
                     <Input placeholder="Friendly identifier" />
                   </Form.Item>
@@ -441,9 +441,9 @@ const AppContent = ({
       >
         <Form form={editForm} layout="vertical">
           <Form.Item
-            label="Key"
+            label="Name"
             name="name"
-            rules={[{ required: true, message: 'Key is required', whitespace: true }]}
+            rules={[{ required: true, message: 'Name is required', whitespace: true }]}
           >
             <Input placeholder="Friendly identifier" />
           </Form.Item>


### PR DESCRIPTION
## Summary
- rename the endpoint creation form field label from "Key" to "Name"
- update the edit modal to use the "Name" label and validation messaging

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cfced7a8b8832d9df00e6da553e0da