### PR TITLE
Add QA health check endpoint and auto refresh UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ npm test
 
 The frontend relies on manual verification for this assignment; the UI is intentionally kept minimal to reflect a 2–3 hour implementation window.
 
+## QA health check endpoint
+
+The deployment also exposes a public `/health-qa` Lambda that intentionally returns a mix of fast successes, slow responses, 4xx/5xx errors, redirects, and even simulated timeouts/exceptions. It is meant for validating that monitoring or alerting rules react correctly to unpredictable behaviour.
+
+To exercise it after deploying the stack:
+
+1. Capture the base URL of the API Gateway stage. You can run `npx serverless info --stage <stage>` from the `backend/` folder or open the API in the AWS console to copy the base invoke URL (for example `https://abc123.execute-api.us-east-1.amazonaws.com/dev`).
+2. Append `/health-qa` to that base URL to form the full endpoint (for example `https://abc123.execute-api.us-east-1.amazonaws.com/dev/health-qa`).
+3. Call the URL from your browser or using a tool like `curl`/Postman to observe the randomly selected scenario on each request.
+
 ## Deployment & operations
 
 ### Architecture choices

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -178,6 +178,14 @@ functions:
           - dynamodb:*
         Resource: !GetAtt CustomerEndpointsTable.Arn
 
+  healthQa:
+    handler: src/functions/health-qa.handler
+    events:
+      - http:
+          path: health-qa
+          method: get
+          cors: true
+
 resources:
   - ${file(resources/cognito-user-pool.yml)}
   - ${file(resources/dynamodb-tables.yml)}

--- a/backend/src/functions/health-qa.ts
+++ b/backend/src/functions/health-qa.ts
@@ -1,0 +1,197 @@
+import { APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { logLambdaEvent } from '@common/log-event';
+
+const COMMON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Header': '*',
+  'Access-Control-Allow-Methods': '*',
+} as const;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type ResponseOutcome = {
+  type: 'response';
+  name: string;
+  statusCode: number;
+  message: string;
+  delayMs?: number;
+  headers?: Record<string, string>;
+};
+
+type TimeoutOutcome = {
+  type: 'timeout';
+  name: string;
+  message: string;
+};
+
+type ThrowOutcome = {
+  type: 'throw';
+  name: string;
+  message: string;
+};
+
+type Outcome = ResponseOutcome | TimeoutOutcome | ThrowOutcome;
+
+const OUTCOMES: Outcome[] = [
+  {
+    type: 'response',
+    name: 'fast-success',
+    statusCode: 200,
+    message: 'Simulated healthy response',
+  },
+  {
+    type: 'response',
+    name: 'slow-success',
+    statusCode: 200,
+    message: 'Healthy response after a noticeable delay',
+    delayMs: 7000,
+  },
+  {
+    type: 'response',
+    name: 'created-success',
+    statusCode: 201,
+    message: 'Simulated resource creation response',
+  },
+  {
+    type: 'response',
+    name: 'no-content',
+    statusCode: 204,
+    message: 'Simulated response with no body content',
+  },
+  {
+    type: 'response',
+    name: 'bad-request',
+    statusCode: 400,
+    message: 'Simulated 400 Bad Request',
+  },
+  {
+    type: 'response',
+    name: 'unauthorized',
+    statusCode: 401,
+    message: 'Simulated 401 Unauthorized',
+  },
+  {
+    type: 'response',
+    name: 'forbidden',
+    statusCode: 403,
+    message: 'Simulated 403 Forbidden',
+  },
+  {
+    type: 'response',
+    name: 'not-found',
+    statusCode: 404,
+    message: 'Simulated 404 Not Found',
+  },
+  {
+    type: 'response',
+    name: 'conflict',
+    statusCode: 409,
+    message: 'Simulated 409 Conflict',
+  },
+  {
+    type: 'response',
+    name: 'rate-limited',
+    statusCode: 429,
+    message: 'Simulated 429 Too Many Requests',
+  },
+  {
+    type: 'response',
+    name: 'server-error',
+    statusCode: 500,
+    message: 'Simulated 500 Internal Server Error',
+  },
+  {
+    type: 'response',
+    name: 'bad-gateway',
+    statusCode: 502,
+    message: 'Simulated 502 Bad Gateway',
+  },
+  {
+    type: 'response',
+    name: 'service-unavailable',
+    statusCode: 503,
+    message: 'Simulated 503 Service Unavailable',
+  },
+  {
+    type: 'response',
+    name: 'gateway-timeout',
+    statusCode: 504,
+    message: 'Simulated 504 Gateway Timeout response',
+  },
+  {
+    type: 'response',
+    name: 'teapot',
+    statusCode: 418,
+    message: "Simulated 418 I'm a teapot", // fun unexpected status
+  },
+  {
+    type: 'response',
+    name: 'redirect',
+    statusCode: 302,
+    message: 'Simulated redirect to an alternate location',
+    headers: {
+      Location: 'https://example.com/maintenance',
+    },
+  },
+  {
+    type: 'throw',
+    name: 'unhandled-exception',
+    message: 'Simulated unexpected runtime failure',
+  },
+  {
+    type: 'timeout',
+    name: 'timeout',
+    message: 'Simulated function timeout',
+  },
+];
+
+const buildResponse = (
+  outcome: ResponseOutcome
+): APIGatewayProxyResult => {
+  const headers = {
+    ...COMMON_HEADERS,
+    ...(outcome.headers ?? {}),
+  };
+
+  const bodyContent =
+    outcome.statusCode === 204
+      ? ''
+      : JSON.stringify({
+          outcome: outcome.name,
+          statusCode: outcome.statusCode,
+          message: outcome.message,
+          timestamp: new Date().toISOString(),
+        });
+
+  return {
+    statusCode: outcome.statusCode,
+    headers,
+    body: bodyContent,
+  };
+};
+
+export const handler = async (
+  event: APIGatewayEvent
+): Promise<APIGatewayProxyResult> => {
+  logLambdaEvent('Received health-qa request', event);
+
+  const outcome = OUTCOMES[Math.floor(Math.random() * OUTCOMES.length)];
+  console.log('Selected health-qa scenario', outcome);
+
+  if (outcome.type === 'timeout') {
+    console.warn('Simulating timeout for /health-qa request');
+    return new Promise<APIGatewayProxyResult>(() => {});
+  }
+
+  if (outcome.type === 'throw') {
+    console.error('Throwing simulated failure for /health-qa request');
+    throw new Error(outcome.message);
+  }
+
+  if (outcome.delayMs) {
+    await delay(outcome.delayMs);
+  }
+
+  return buildResponse(outcome);
+};

--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -185,9 +185,16 @@ const AppContent = ({
   const [deletingTenantId, setDeletingTenantId] = useState<string | null>(null);
 
   useEffect(() => {
-    loadEndpoints();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void loadEndpoints();
+
+    const intervalId = window.setInterval(() => {
+      void loadEndpoints();
+    }, 30_000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [loadEndpoints]);
 
   const groupedEndpoints = useMemo(() => groupByTenantAndCategory(endpoints), [endpoints]);
 


### PR DESCRIPTION
## Summary
- add a public /health-qa lambda that randomly responds with success, client errors, server errors, redirects, timeouts, and exceptions for integration testing
- register the QA route in the Serverless configuration so it is deployed without an authorizer
- refresh the monitored endpoints view automatically every 30 seconds in the frontend

## Testing
- npm run build (backend)
- npm test (backend)
- npm test -- --watchAll=false --passWithNoTests (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d025d80960832d9e8b5c2a916fc7a9