### PR TITLE
Clear stale error messages after successful health check

### DIFF
--- a/backend/__tests__/endpoint-service.test.ts
+++ b/backend/__tests__/endpoint-service.test.ts
@@ -1,0 +1,77 @@
+import { endpointService } from '@service/endpoint-service';
+import { EndpointStore } from '@store/endpoint-store';
+import { EndpointModel } from '@model/endpoint-model';
+import * as checkEndpointModule from '@lib/check-endpoint';
+import { notificationService } from '@service/notification-service';
+
+describe('endpointService.refreshEndpoints', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clears existing error details when an endpoint recovers', async () => {
+    const existingEndpoint: EndpointModel = {
+      ownerId: 'owner-1',
+      endpointId: 'endpoint-1',
+      tenantId: 'tenant',
+      category: 'category',
+      name: 'Example',
+      url: 'https://example.com/health',
+      timeoutMs: 5000,
+      status: 'unhealthy',
+      statusCode: 429,
+      responseTimeMs: 100,
+      errorMessage: 'Non-2xx status code: 429',
+      statusSince: '2024-01-01T00:00:00.000Z',
+      lastCheckedAt: '2024-01-01T00:00:00.000Z',
+      createdAt: '2023-12-31T00:00:00.000Z',
+      updatedAt: '2023-12-31T00:00:00.000Z',
+    } as EndpointModel;
+
+    const listEndpointsSpy = jest
+      .spyOn(
+        (endpointService as unknown as { endpointStore: EndpointStore }).endpointStore,
+        'listEndpoints'
+      )
+      .mockResolvedValue([existingEndpoint]);
+
+    const updateSpy = jest
+      .spyOn(
+        (endpointService as unknown as { endpointStore: EndpointStore }).endpointStore,
+        'updateEndpoint'
+      )
+      .mockImplementation(async (_ownerId, _endpointId, update) => ({
+        ...existingEndpoint,
+        ...update,
+      }));
+
+    jest.spyOn(checkEndpointModule, 'CheckEndpoint').mockResolvedValue({
+      status: 'healthy',
+      statusCode: 200,
+      responseTimeMs: 42,
+    });
+
+    const notifySpy = jest
+      .spyOn(notificationService, 'notifyEndpointIssue')
+      .mockResolvedValue();
+
+    const [updatedEndpoint] = await endpointService.refreshEndpoints(
+      existingEndpoint.ownerId
+    );
+
+    expect(listEndpointsSpy).toHaveBeenCalledWith(existingEndpoint.ownerId);
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      existingEndpoint.ownerId,
+      existingEndpoint.endpointId,
+      expect.objectContaining({
+        status: 'healthy',
+        errorMessage: null,
+      })
+    );
+
+    expect(updatedEndpoint.status).toBe('healthy');
+    expect(updatedEndpoint.errorMessage).toBeNull();
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/model/endpoint-model.ts
+++ b/backend/src/model/endpoint-model.ts
@@ -19,7 +19,7 @@ export class EndpointModel extends BaseDynamoModel implements EndpointInterface 
   status: EndpointInterface['status'];
   statusCode?: number;
   responseTimeMs?: number;
-  errorMessage?: string;
+  errorMessage?: string | null;
   lastCheckedAt?: string;
   statusSince?: string;
 }

--- a/backend/src/service/endpoint-service.ts
+++ b/backend/src/service/endpoint-service.ts
@@ -160,11 +160,16 @@ class EndpointService {
     const statusChanged = endpoint.status !== newStatus;
     const nowIso = new Date().toISOString();
 
+    const errorMessage =
+      checkResult.status === 'healthy'
+        ? null
+        : checkResult.errorMessage ?? null;
+
     const updatePayload: Partial<EndpointModel> = {
       status: newStatus,
       statusCode: checkResult.statusCode,
       responseTimeMs: checkResult.responseTimeMs,
-      errorMessage: checkResult.errorMessage,
+      errorMessage,
       lastCheckedAt: nowIso,
       statusSince: statusChanged ? nowIso : endpoint.statusSince,
     };

--- a/backend/src/types/Endpoint.ts
+++ b/backend/src/types/Endpoint.ts
@@ -11,7 +11,7 @@ export interface EndpointInterface {
   status: EndpointStatus;
   statusCode?: number;
   responseTimeMs?: number;
-  errorMessage?: string;
+  errorMessage?: string | null;
   lastCheckedAt?: string;
   statusSince?: string;
 }

--- a/frontend/src/types/Endpoint.ts
+++ b/frontend/src/types/Endpoint.ts
@@ -11,7 +11,7 @@ export type Endpoint = {
   status: EndpointStatus;
   statusCode?: number;
   responseTimeMs?: number;
-  errorMessage?: string;
+  errorMessage?: string | null;
   lastCheckedAt?: string;
   statusSince?: string;
 };


### PR DESCRIPTION
## Summary
- clear stale error message data when an endpoint returns to a healthy status
- allow endpoint models and frontend types to represent a cleared error message as null
- add a unit test verifying that recovery removes the prior error details

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d02c473848832dbd70e335a5521d5e