### PR TITLE
Fix endpoint refresh handling and add endpoint deletion

### DIFF
--- a/backend/__tests__/endpoint-service.test.ts
+++ b/backend/__tests__/endpoint-service.test.ts
@@ -4,42 +4,76 @@ import { EndpointModel } from '@model/endpoint-model';
 import * as checkEndpointModule from '@lib/check-endpoint';
 import { notificationService } from '@service/notification-service';
 
+const endpointStore =
+  (endpointService as unknown as { endpointStore: EndpointStore }).endpointStore;
+
+const buildEndpoint = (overrides: Partial<EndpointModel> = {}): EndpointModel =>
+  ({
+    ownerId: 'owner-1',
+    endpointId: 'endpoint-1',
+    tenantId: 'tenant',
+    category: 'category',
+    name: 'Example',
+    url: 'https://example.com/health',
+    timeoutMs: 5000,
+    status: 'unhealthy',
+    statusCode: 429,
+    responseTimeMs: 100,
+    errorMessage: 'Non-2xx status code: 429',
+    statusSince: '2024-01-01T00:00:00.000Z',
+    lastCheckedAt: '2024-01-01T00:00:00.000Z',
+    createdAt: '2023-12-31T00:00:00.000Z',
+    updatedAt: '2023-12-31T00:00:00.000Z',
+    ...overrides,
+  }) as EndpointModel;
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe('endpointService.refreshEndpoints', () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+  it('removes stale error details when an endpoint recovers', async () => {
+    const existingEndpoint = buildEndpoint();
 
-  it('clears existing error details when an endpoint recovers', async () => {
-    const existingEndpoint: EndpointModel = {
-      ownerId: 'owner-1',
-      endpointId: 'endpoint-1',
-      tenantId: 'tenant',
-      category: 'category',
-      name: 'Example',
-      url: 'https://example.com/health',
-      timeoutMs: 5000,
-      status: 'unhealthy',
-      statusCode: 429,
-      responseTimeMs: 100,
-      errorMessage: 'Non-2xx status code: 429',
-      statusSince: '2024-01-01T00:00:00.000Z',
-      lastCheckedAt: '2024-01-01T00:00:00.000Z',
-      createdAt: '2023-12-31T00:00:00.000Z',
-      updatedAt: '2023-12-31T00:00:00.000Z',
-    } as EndpointModel;
-
-    const listEndpointsSpy = jest
-      .spyOn(
-        (endpointService as unknown as { endpointStore: EndpointStore }).endpointStore,
-        'listEndpoints'
-      )
-      .mockResolvedValue([existingEndpoint]);
+    jest.spyOn(endpointStore, 'listEndpoints').mockResolvedValue([existingEndpoint]);
 
     const updateSpy = jest
-      .spyOn(
-        (endpointService as unknown as { endpointStore: EndpointStore }).endpointStore,
-        'updateEndpoint'
-      )
+      .spyOn(endpointStore, 'updateEndpoint')
+      .mockImplementation(async (_ownerId, _endpointId, update) => ({
+        ...existingEndpoint,
+        ...update,
+      }));
+
+    jest.spyOn(checkEndpointModule, 'CheckEndpoint').mockResolvedValue({
+      status: 'healthy',
+      statusCode: 200,
+      responseTimeMs: 42,
+    });
+
+    jest.spyOn(notificationService, 'notifyEndpointIssue').mockResolvedValue();
+
+    const [updatedEndpoint] = await endpointService.refreshEndpoints(
+      existingEndpoint.ownerId
+    );
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      existingEndpoint.ownerId,
+      existingEndpoint.endpointId,
+      expect.objectContaining({
+        status: 'healthy',
+        errorMessage: null,
+      })
+    );
+    expect(updatedEndpoint.errorMessage).toBeNull();
+  });
+
+  it('does not send notifications when a refreshed endpoint is healthy', async () => {
+    const existingEndpoint = buildEndpoint();
+
+    jest.spyOn(endpointStore, 'listEndpoints').mockResolvedValue([existingEndpoint]);
+
+    jest
+      .spyOn(endpointStore, 'updateEndpoint')
       .mockImplementation(async (_ownerId, _endpointId, update) => ({
         ...existingEndpoint,
         ...update,
@@ -55,23 +89,45 @@ describe('endpointService.refreshEndpoints', () => {
       .spyOn(notificationService, 'notifyEndpointIssue')
       .mockResolvedValue();
 
-    const [updatedEndpoint] = await endpointService.refreshEndpoints(
-      existingEndpoint.ownerId
-    );
+    await endpointService.refreshEndpoints(existingEndpoint.ownerId);
 
-    expect(listEndpointsSpy).toHaveBeenCalledWith(existingEndpoint.ownerId);
-
-    expect(updateSpy).toHaveBeenCalledWith(
-      existingEndpoint.ownerId,
-      existingEndpoint.endpointId,
-      expect.objectContaining({
-        status: 'healthy',
-        errorMessage: null,
-      })
-    );
-
-    expect(updatedEndpoint.status).toBe('healthy');
-    expect(updatedEndpoint.errorMessage).toBeNull();
     expect(notifySpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('endpointService.deleteEndpoint', () => {
+  it('throws a validation error when endpointId is empty', async () => {
+    await expect(endpointService.deleteEndpoint('owner-1', '   ')).rejects.toMatchObject({
+      message: 'endpointId cannot be empty',
+      statusCode: 400,
+    });
+  });
+
+  it('throws a not found error when the endpoint does not exist', async () => {
+    jest.spyOn(endpointStore, 'getEndpoint').mockResolvedValue(null);
+
+    await expect(
+      endpointService.deleteEndpoint('owner-1', 'missing-endpoint')
+    ).rejects.toMatchObject({
+      message: 'Endpoint not found',
+      statusCode: 404,
+    });
+  });
+
+  it('removes the endpoint when it exists', async () => {
+    const existingEndpoint = buildEndpoint({ endpointId: 'endpoint-123' });
+
+    jest.spyOn(endpointStore, 'getEndpoint').mockResolvedValue(existingEndpoint);
+
+    const deleteSpy = jest
+      .spyOn(endpointStore, 'deleteEndpoint')
+      .mockResolvedValue();
+
+    await endpointService.deleteEndpoint(existingEndpoint.ownerId, '  endpoint-123  ');
+
+    expect(deleteSpy).toHaveBeenCalledWith(
+      existingEndpoint.ownerId,
+      existingEndpoint.endpointId
+    );
   });
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -148,6 +148,23 @@ functions:
           - dynamodb:*
         Resource: !GetAtt CustomerEndpointsTable.Arn
 
+  deleteEndpoint:
+    handler: src/functions/endpoints/delete-endpoint.handler
+    events:
+      - http:
+          authorizer:
+            type: COGNITO_USER_POOLS
+            authorizerId:
+              Ref: ApiGatewayAuthorizer
+          path: monitoring/endpoints/{endpointId}
+          method: delete
+          cors: true
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:*
+        Resource: !GetAtt CustomerEndpointsTable.Arn
+
   refreshAllEndpoints:
     handler: src/functions/endpoints/refresh-all-endpoints.handler
     events:

--- a/backend/src/functions/endpoints/delete-endpoint.ts
+++ b/backend/src/functions/endpoints/delete-endpoint.ts
@@ -1,0 +1,30 @@
+import { endpointService } from '@service/endpoint-service';
+import { httpError, httpResponse } from '@common/http-response';
+import { logLambdaEvent } from '@common/log-event';
+import { APIGatewayEvent } from 'aws-lambda';
+
+export const handler = async (event: APIGatewayEvent) => {
+  logLambdaEvent('Received delete-endpoint request', event);
+  try {
+    const claims = event.requestContext.authorizer?.claims;
+    const ownerId = claims?.sub;
+
+    if (!ownerId) {
+      return httpError(new Error('Unauthorized'), 401);
+    }
+
+    const endpointId = event.pathParameters?.endpointId;
+
+    if (!endpointId) {
+      return httpError(new Error('endpointId path parameter is required'), 400);
+    }
+
+    await endpointService.deleteEndpoint(ownerId, endpointId);
+
+    return httpResponse(undefined, 204);
+  } catch (err) {
+    console.error('Error deleting endpoint', { error: err });
+    const error = err instanceof Error ? err : new Error('Unexpected error');
+    return httpError(error, (error as any).statusCode || 500);
+  }
+};

--- a/backend/src/model/dynamo-store-repository.ts
+++ b/backend/src/model/dynamo-store-repository.ts
@@ -42,9 +42,18 @@ export class DynamoStoreRepository<T extends BaseDynamoModel> extends DynamoStor
 
   private patch(updateWith: Partial<T>, updateRequest: UpdateRequest<T>) {
     for (const [attrKey, attrValue] of Object.entries(updateWith)) {
-      updateRequest = updateRequest
-        .updateAttribute(attrKey as keyof T)
-        .set(attrValue as T[keyof T]);
+      if (attrValue === undefined) {
+        continue;
+      }
+
+      const attribute = updateRequest.updateAttribute(attrKey as keyof T);
+
+      if (attrValue === null) {
+        updateRequest = attribute.remove();
+        continue;
+      }
+
+      updateRequest = attribute.set(attrValue as T[keyof T]);
     }
     updateRequest.updateAttribute('updatedAt').set(new Date().toISOString());
     return updateRequest.returnValues('ALL_NEW').exec();

--- a/backend/src/service/endpoint-service.ts
+++ b/backend/src/service/endpoint-service.ts
@@ -101,6 +101,35 @@ class EndpointService {
     return this.endpointStore.updateEndpoint(ownerId, endpointId, sanitizedUpdate);
   };
 
+  deleteEndpoint = async (ownerId: string, endpointId: string): Promise<void> => {
+    if (!endpointId) {
+      const error = new Error('endpointId is required');
+      (error as any).statusCode = 400;
+      throw error;
+    }
+
+    const normalizedEndpointId = endpointId.trim();
+
+    if (!normalizedEndpointId) {
+      const error = new Error('endpointId cannot be empty');
+      (error as any).statusCode = 400;
+      throw error;
+    }
+
+    const existingEndpoint = await this.endpointStore.getEndpoint(
+      ownerId,
+      normalizedEndpointId
+    );
+
+    if (!existingEndpoint) {
+      const error = new Error('Endpoint not found');
+      (error as any).statusCode = 404;
+      throw error;
+    }
+
+    await this.endpointStore.deleteEndpoint(ownerId, normalizedEndpointId);
+  };
+
   listEndpoints = async (ownerId: string): Promise<EndpointModel[]> => {
     return this.endpointStore.listEndpoints(ownerId);
   };
@@ -183,6 +212,10 @@ class EndpointService {
       endpoint.endpointId,
       sanitizedUpdatePayload
     );
+
+    if (errorMessage === null) {
+      updatedEndpoint.errorMessage = null;
+    }
 
     await this.notifyIfUnhealthy(updatedEndpoint, checkResult);
 


### PR DESCRIPTION
## Summary
- treat null values in DynamoDB updates as attribute removals to stop refresh failures
- add service and Lambda handler support for deleting individual endpoints and exposing the API route
- split endpoint service unit tests by operation and cover refreshed error clearing and deletion flows

## Testing
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0333dba7c832d9320c9a053f0f44c