### PR TITLE
Add endpoint deletion to frontend

### DIFF
--- a/frontend/src/components/AppContent.tsx
+++ b/frontend/src/components/AppContent.tsx
@@ -175,6 +175,7 @@ const AppContent = ({
     loadEndpoints,
     addEndpoint,
     updateEndpoint,
+    deleteEndpoint,
     deleteTenant,
   } = useEndpoints();
   const [form] = Form.useForm<EndpointPayload & { timeoutMs?: number }>();
@@ -183,6 +184,7 @@ const AppContent = ({
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [isUpdatingEndpoint, setIsUpdatingEndpoint] = useState(false);
   const [deletingTenantId, setDeletingTenantId] = useState<string | null>(null);
+  const [deletingEndpointId, setDeletingEndpointId] = useState<string | null>(null);
 
   useEffect(() => {
     void loadEndpoints();
@@ -256,6 +258,22 @@ const AppContent = ({
     }
   };
 
+  const handleDeleteEndpoint = async (endpoint: Endpoint) => {
+    setDeletingEndpointId(endpoint.endpointId);
+    try {
+      await deleteEndpoint(endpoint.endpointId);
+      message.success(`Deleted endpoint ${endpoint.name}`);
+
+      if (editingEndpoint?.endpointId === endpoint.endpointId) {
+        handleEditModalClose();
+      }
+    } catch (error) {
+      message.error('Failed to delete endpoint');
+    } finally {
+      setDeletingEndpointId(null);
+    }
+  };
+
   const onSubmit = async (values: EndpointPayload & { timeoutMs?: number }) => {
     try {
       await addEndpoint({
@@ -284,6 +302,27 @@ const AppContent = ({
         >
           Edit
         </Button>,
+        <Popconfirm
+          key={`delete-${endpoint.endpointId}`}
+          title="Delete endpoint"
+          description={`This will remove ${endpoint.name}.`}
+          okText="Delete"
+          cancelText="Cancel"
+          okButtonProps={{
+            danger: true,
+            loading: deletingEndpointId === endpoint.endpointId,
+          }}
+          onConfirm={() => handleDeleteEndpoint(endpoint)}
+        >
+          <Button
+            type="link"
+            danger
+            size="small"
+            loading={deletingEndpointId === endpoint.endpointId}
+          >
+            Delete
+          </Button>
+        </Popconfirm>,
       ]}
     >
       <List.Item.Meta

--- a/frontend/src/hooks/useEndpoints.ts
+++ b/frontend/src/hooks/useEndpoints.ts
@@ -89,6 +89,19 @@ const useEndpoints = () => {
     []
   );
 
+  const deleteEndpoint = useCallback(async (endpointId: string) => {
+    try {
+      await API.del(API_NAME, `${ENDPOINT_PATH}/${endpointId}`, {});
+
+      setEndpoints((prev) =>
+        sortEndpoints(prev.filter((endpoint) => endpoint.endpointId !== endpointId))
+      );
+    } catch (error) {
+      console.error('Error deleting endpoint:', error);
+      throw error;
+    }
+  }, []);
+
   const deleteTenant = useCallback(async (tenantId: string) => {
     try {
       const response: { deletedCount?: number } = await API.del(
@@ -115,6 +128,7 @@ const useEndpoints = () => {
     loadEndpoints,
     addEndpoint,
     updateEndpoint,
+    deleteEndpoint,
     deleteTenant,
   };
 };


### PR DESCRIPTION
## Summary
- call the API for deleting individual endpoints from the React hook
- add a delete action with confirmation and loading states for each endpoint card

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d03b7c31a4832dab71c7623d41065e